### PR TITLE
Update Startup.cs for GH Codespaces

### DIFF
--- a/MapsCustomConnector/Startup.cs
+++ b/MapsCustomConnector/Startup.cs
@@ -1,8 +1,12 @@
-﻿using MapsCustomConnector.Configs;
+﻿using System;
+
+using MapsCustomConnector.Configs;
 using MapsCustomConnector.Services;
 
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Configurations.AppSettings.Extensions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Configurations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -38,6 +42,22 @@ namespace MapsCustomConnector
                                    .GetService<IConfiguration>()
                                    .Get<MapsSettings>(MapsSettings.Name);
             services.AddSingleton(settings);
+
+            var codespaces = bool.TryParse(Environment.GetEnvironmentVariable("OpenApi__RunOnCodespaces"), out var isCodespaces) && isCodespaces;
+            if (codespaces)
+            {
+                /* ⬇️⬇️⬇️ Add this ⬇️⬇️⬇️ */
+                services.AddSingleton<IOpenApiConfigurationOptions>(_ =>
+                        {
+                            var options = new DefaultOpenApiConfigurationOptions()
+                            {
+                                IncludeRequestingHostName = false
+                            };
+
+                            return options;
+                        });
+                /* ⬆️⬆️⬆️ Add this ⬆️⬆️⬆️ */
+            }
         }
 
         private static void ConfigureClients(IServiceCollection services)

--- a/MapsCustomConnector/local.settings.sample.json
+++ b/MapsCustomConnector/local.settings.sample.json
@@ -12,6 +12,11 @@
     "Maps__Google__ApiKey": "<GOOGLE_MAPS_API_KEY>",
 
     "Maps__Naver__ClientId": "<NAVER_MAP_API_CLIENT_ID>",
-    "Maps__Naver__ClientSecret": "<NAVER_MAP_API_CLIENT_SECRET>"
+    "Maps__Naver__ClientSecret": "<NAVER_MAP_API_CLIENT_SECRET>",
+
+    // Only for use on GitHub Codespaces
+    "OpenApi__ForceHttps": "true",
+    "OpenApi__HostNames": "https://google-naver-maps-custom-connector-sample-<CODESPACE_NAME>-7071.githubpreview.dev/api",
+    "OpenApi__RunOnCodespaces": "true"
   }
 }


### PR DESCRIPTION
Currently, GitHub Codespaces uses port forwarding for the local degugging. However, with regards to the Swagger UI, page, the port forwarding blocks the localhost app from rendering the Swagger UI by CORS.

Therefore, this PR is to configure the app being able to work on GitHub Codespaces without being blocked by CORS.
